### PR TITLE
Upgrade ionic-angular to 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ yarn
 # Or npm install
 
 # Compile typescript into dist
-npm run build
+yarn build
+# Or npm run build
 
 yarn link
 # Or npm pack

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -9,6 +9,7 @@
     "ionic:serve": "ionic-app-scripts serve"
   },
   "dependencies": {
+    "@angular/animations": "4.0.1",
     "@angular/common": "4.0.1",
     "@angular/compiler": "4.0.1",
     "@angular/compiler-cli": "4.0.1",
@@ -26,7 +27,7 @@
     "@ngrx/effects": "2.0.2",
     "@ngrx/store": "2.2.1",
     "@ngrx/store-devtools": "3.2.4",
-    "ionic-angular": "2.3.0",
+    "ionic-angular": "3.0.0",
     "ionicons": "3.0.0",
     "ngrx-store-freeze": "0.1.9",
     "ngrx-store-logger": "0.1.7",
@@ -35,6 +36,7 @@
     "zone.js": "0.8.5"
   },
   "devDependencies": {
+    "@angular/tsc-wrapped": "4.0.1",
     "@ionic/app-scripts": "1.2.5",
     "@ionic/cli-build-ionic-angular": "0.0.4",
     "@ionic/cli-plugin-cordova": "0.0.10",

--- a/mobile/yarn.lock
+++ b/mobile/yarn.lock
@@ -2,6 +2,10 @@
 # yarn lockfile v1
 
 
+"@angular/animations@4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@angular/animations/-/animations-4.0.1.tgz#154420c8ee5c22fbaf1434b6d156150cf5218da6"
+
 "@angular/common@4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@angular/common/-/common-4.0.1.tgz#df488eada842b2d841ded750712292b18387b5b0"
@@ -1796,9 +1800,9 @@ invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
 
-ionic-angular@2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/ionic-angular/-/ionic-angular-2.3.0.tgz#28adadbe8c54dd5eda8e113cdd18819474e42c71"
+ionic-angular@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ionic-angular/-/ionic-angular-3.0.0.tgz#783f09f1d8002aeabaae79f1c691812844bf5881"
 
 ionicons@3.0.0:
   version "3.0.0"


### PR DESCRIPTION
ionic-angular was still at 2.3.0, but 3.0.0 is available. Added missing deps for it and improved the README for one yarn command.
closes #8 